### PR TITLE
feat(generator): improve quiz generation

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -5,7 +5,7 @@ import { parseCardSections, parseQuizQuestions } from './src/lib/content/parsers
 const DifficultySchema = z.enum(['easy', 'medium', 'hard'])
 const FlashcardDifficultySchema = DifficultySchema
 
-const QuizTypeSchema = z.enum(['pattern-selection', 'anti-patterns', 'big-o'])
+const QuizTypeSchema = z.string()
 
 const getGroupTitle = (subcategory: string, id: string): string => {
 	const subcategoryTitle = subcategory

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -5,7 +5,10 @@ import { parseCardSections, parseQuizQuestions } from './src/lib/content/parsers
 const DifficultySchema = z.enum(['easy', 'medium', 'hard'])
 const FlashcardDifficultySchema = DifficultySchema
 
-const QuizTypeSchema = z.string()
+const QuizTypeSchema = z
+	.string()
+	.min(1)
+	.refine((s) => s.trim().length > 0, { message: 'Quiz type cannot be blank' })
 
 const getGroupTitle = (subcategory: string, id: string): string => {
 	const subcategoryTitle = subcategory

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as lib_auth from "../lib/auth.js";
 import type * as lib_dateHelpers from "../lib/dateHelpers.js";
 import type * as quizAnswers from "../quizAnswers.js";
 import type * as quizContent from "../quizContent.js";
+import type * as quizGeneration from "../quizGeneration.js";
 import type * as quizSessions from "../quizSessions.js";
 import type * as users from "../users.js";
 
@@ -34,6 +35,7 @@ declare const fullApi: ApiFromModules<{
   "lib/dateHelpers": typeof lib_dateHelpers;
   quizAnswers: typeof quizAnswers;
   quizContent: typeof quizContent;
+  quizGeneration: typeof quizGeneration;
   quizSessions: typeof quizSessions;
   users: typeof users;
 }>;

--- a/convex/quizContent.ts
+++ b/convex/quizContent.ts
@@ -76,9 +76,6 @@ export const create = mutation({
 				mistakes: v.optional(v.string()),
 			}),
 		),
-		status: v.optional(
-			v.union(v.literal('draft'), v.literal('published')),
-		),
 		sourcePrompt: v.optional(v.string()),
 	},
 	handler: async (ctx, args) => {
@@ -95,7 +92,7 @@ export const create = mutation({
 
 		return await ctx.db.insert('quizContent', {
 			...args,
-			status: args.status ?? 'draft',
+			status: 'draft',
 			createdBy: user._id,
 		})
 	},
@@ -162,6 +159,33 @@ export const publish = mutation({
 		}
 		if (draft.createdBy !== user._id) {
 			throw new ConvexError('Not authorized to publish this draft')
+		}
+
+		if (!draft.title?.trim()) {
+			throw new ConvexError('Quiz must have a non-empty title before publishing')
+		}
+		if (!draft.type?.trim()) {
+			throw new ConvexError('Quiz must have a non-empty type before publishing')
+		}
+		if (!draft.category?.trim()) {
+			throw new ConvexError('Quiz must have a category before publishing')
+		}
+		if (!draft.subcategory?.trim()) {
+			throw new ConvexError('Quiz must have a subcategory before publishing')
+		}
+		if (!draft.questions || draft.questions.length === 0) {
+			throw new ConvexError('Quiz must have at least one question before publishing')
+		}
+		for (const q of draft.questions) {
+			if (!q.question?.trim()) {
+				throw new ConvexError('All questions must have non-empty prompt text')
+			}
+			if (!q.options || q.options.length === 0) {
+				throw new ConvexError('All questions must have answer options')
+			}
+			if (!q.answer?.trim()) {
+				throw new ConvexError('All questions must have an answer')
+			}
 		}
 
 		await ctx.db.patch(draft._id, { status: 'published' })

--- a/convex/quizContent.ts
+++ b/convex/quizContent.ts
@@ -5,7 +5,8 @@ import { getAuthenticatedUser } from './lib/auth'
 export const list = query({
 	args: {},
 	handler: async (ctx) => {
-		return await ctx.db.query('quizContent').collect()
+		const all = await ctx.db.query('quizContent').collect()
+		return all.filter((q) => q.status !== 'draft')
 	},
 })
 
@@ -21,14 +22,41 @@ export const getByContentId = query({
 	},
 })
 
+export const listDrafts = query({
+	args: {},
+	handler: async (ctx) => {
+		const user = await getAuthenticatedUser(ctx)
+		const all = await ctx.db
+			.query('quizContent')
+			.withIndex('byStatus', (q) => q.eq('status', 'draft'))
+			.collect()
+		return all.filter((q) => q.createdBy === user._id)
+	},
+})
+
+export const getDraft = query({
+	args: {
+		contentId: v.string(),
+	},
+	handler: async (ctx, args) => {
+		const user = await getAuthenticatedUser(ctx)
+		const draft = await ctx.db
+			.query('quizContent')
+			.withIndex('byContentId', (q) => q.eq('contentId', args.contentId))
+			.unique()
+
+		if (!draft || draft.status !== 'draft' || draft.createdBy !== user._id) {
+			return null
+		}
+
+		return draft
+	},
+})
+
 export const create = mutation({
 	args: {
 		contentId: v.string(),
-		type: v.union(
-			v.literal('pattern-selection'),
-			v.literal('anti-patterns'),
-			v.literal('big-o'),
-		),
+		type: v.string(),
 		category: v.string(),
 		subcategory: v.string(),
 		difficulty: v.union(
@@ -48,6 +76,10 @@ export const create = mutation({
 				mistakes: v.optional(v.string()),
 			}),
 		),
+		status: v.optional(
+			v.union(v.literal('draft'), v.literal('published')),
+		),
+		sourcePrompt: v.optional(v.string()),
 	},
 	handler: async (ctx, args) => {
 		const user = await getAuthenticatedUser(ctx)
@@ -63,8 +95,76 @@ export const create = mutation({
 
 		return await ctx.db.insert('quizContent', {
 			...args,
+			status: args.status ?? 'draft',
 			createdBy: user._id,
 		})
+	},
+})
+
+export const updateDraft = mutation({
+	args: {
+		contentId: v.string(),
+		title: v.optional(v.string()),
+		type: v.optional(v.string()),
+		category: v.optional(v.string()),
+		subcategory: v.optional(v.string()),
+		difficulty: v.optional(
+			v.union(
+				v.literal('easy'),
+				v.literal('medium'),
+				v.literal('hard'),
+			),
+		),
+		tags: v.optional(v.array(v.string())),
+	},
+	handler: async (ctx, args) => {
+		const user = await getAuthenticatedUser(ctx)
+		const draft = await ctx.db
+			.query('quizContent')
+			.withIndex('byContentId', (q) => q.eq('contentId', args.contentId))
+			.unique()
+
+		if (!draft) {
+			throw new ConvexError('Draft not found')
+		}
+		if (draft.status !== 'draft') {
+			throw new ConvexError('Only drafts can be edited')
+		}
+		if (draft.createdBy !== user._id) {
+			throw new ConvexError('Not authorized to edit this draft')
+		}
+
+		const { contentId: _, ...updates } = args
+		const fieldsToUpdate = Object.fromEntries(
+			Object.entries(updates).filter(([, v]) => v !== undefined),
+		)
+
+		await ctx.db.patch(draft._id, fieldsToUpdate)
+	},
+})
+
+export const publish = mutation({
+	args: {
+		contentId: v.string(),
+	},
+	handler: async (ctx, args) => {
+		const user = await getAuthenticatedUser(ctx)
+		const draft = await ctx.db
+			.query('quizContent')
+			.withIndex('byContentId', (q) => q.eq('contentId', args.contentId))
+			.unique()
+
+		if (!draft) {
+			throw new ConvexError('Quiz not found')
+		}
+		if (draft.status !== 'draft') {
+			throw new ConvexError('Only drafts can be published')
+		}
+		if (draft.createdBy !== user._id) {
+			throw new ConvexError('Not authorized to publish this draft')
+		}
+
+		await ctx.db.patch(draft._id, { status: 'published' })
 	},
 })
 

--- a/convex/quizGeneration.ts
+++ b/convex/quizGeneration.ts
@@ -1,0 +1,128 @@
+'use node'
+
+import { ConvexError, v } from 'convex/values'
+import { action } from './_generated/server'
+import { api } from './_generated/api'
+import {
+	buildQuizGenerationPrompt,
+	QUIZ_GENERATION_SYSTEM_PROMPT,
+} from '../src/lib/prompts/quiz-generation'
+
+const MODEL = 'claude-sonnet-4-20250514'
+const MAX_TOKENS = 8192
+
+const slugify = (value: string) =>
+	value
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/(^-|-$)/g, '')
+
+const extractJson = (text: string): string => {
+	const start = text.indexOf('{')
+	const end = text.lastIndexOf('}')
+	if (start === -1 || end === -1 || end < start) return text
+	return text.slice(start, end + 1)
+}
+
+type AnthropicMessage = {
+	content: Array<{ type: string; text: string }>
+	error?: { message?: string }
+}
+
+type QuizJson = {
+	type: string
+	subcategory: string
+	category: string
+	difficulty: 'easy' | 'medium' | 'hard'
+	tags: string[]
+	title: string
+	questions: Array<{
+		question: string
+		options: { label: string; text: string }[]
+		answer: string
+		explanation: string
+		mistakes?: string
+	}>
+}
+
+export const generate = action({
+	args: {
+		prompt: v.string(),
+		sourceText: v.optional(v.string()),
+		questionCount: v.number(),
+		difficulty: v.optional(
+			v.union(v.literal('easy'), v.literal('medium'), v.literal('hard')),
+		),
+		category: v.optional(v.string()),
+		subcategory: v.optional(v.string()),
+		tags: v.optional(v.array(v.string())),
+		quizType: v.optional(v.string()),
+	},
+	handler: async (ctx, args) => {
+		const identity = await ctx.auth.getUserIdentity()
+		if (!identity) throw new ConvexError('Not authenticated')
+
+		const apiKey = process.env.ANTHROPIC_API_KEY
+		if (!apiKey) throw new ConvexError('ANTHROPIC_API_KEY not configured')
+
+		const userPrompt = buildQuizGenerationPrompt({
+			prompt: args.prompt,
+			sourceText: args.sourceText,
+			questionCount: args.questionCount,
+			difficulty: args.difficulty,
+			category: args.category,
+			subcategory: args.subcategory,
+			tags: args.tags,
+			quizType: args.quizType,
+		})
+
+		const response = await fetch('https://api.anthropic.com/v1/messages', {
+			method: 'POST',
+			headers: {
+				'x-api-key': apiKey,
+				'anthropic-version': '2023-06-01',
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({
+				model: MODEL,
+				max_tokens: MAX_TOKENS,
+				system: QUIZ_GENERATION_SYSTEM_PROMPT,
+				messages: [{ role: 'user', content: userPrompt }],
+			}),
+		})
+
+		if (!response.ok) {
+			const err = (await response.json().catch(() => ({}))) as AnthropicMessage
+			throw new ConvexError(err.error?.message ?? 'AI generation failed')
+		}
+
+		const data = (await response.json()) as AnthropicMessage
+		const rawText = data.content.find((c) => c.type === 'text')?.text ?? ''
+		const cleanedJson = extractJson(rawText.trim())
+
+		let quiz: QuizJson
+		try {
+			quiz = JSON.parse(cleanedJson) as QuizJson
+		} catch {
+			throw new ConvexError('Failed to parse generated quiz — please try again')
+		}
+
+		const contentId = `${slugify(quiz.type)}-${slugify(quiz.subcategory)}-${Date.now()}`
+
+		await ctx.runMutation(api.quizContent.create, {
+			contentId,
+			type: quiz.type,
+			category: quiz.category,
+			subcategory: quiz.subcategory,
+			difficulty: quiz.difficulty,
+			tags: quiz.tags,
+			version: '1.0.0',
+			title: quiz.title,
+			questions: quiz.questions,
+			sourcePrompt: args.prompt,
+		})
+
+		return contentId
+	},
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -92,11 +92,7 @@ export default defineSchema({
 
 	quizContent: defineTable({
 		contentId: v.string(),
-		type: v.union(
-			v.literal('pattern-selection'),
-			v.literal('anti-patterns'),
-			v.literal('big-o'),
-		),
+		type: v.string(),
 		category: v.string(),
 		subcategory: v.string(),
 		difficulty: v.union(
@@ -116,10 +112,15 @@ export default defineSchema({
 				mistakes: v.optional(v.string()),
 			}),
 		),
+		status: v.optional(
+			v.union(v.literal('draft'), v.literal('published')),
+		),
+		sourcePrompt: v.optional(v.string()),
 		createdBy: v.optional(v.id('users')),
 	})
 		.index('byContentId', ['contentId'])
-		.index('byCategory', ['category']),
+		.index('byCategory', ['category'])
+		.index('byStatus', ['status']),
 
 	flashcardContent: defineTable({
 		contentId: v.string(),

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -11,6 +11,7 @@
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
+    "types": ["node"],
 
     /* These compiler options are required by Convex */
     "target": "ESNext",

--- a/src/components/quiz/QuizList.tsx
+++ b/src/components/quiz/QuizList.tsx
@@ -26,6 +26,9 @@ const typeColors: Record<string, string> = {
 		'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
 }
 
+const DEFAULT_TYPE_COLOR =
+	'bg-slate-100 text-slate-800 dark:bg-slate-900 dark:text-slate-200'
+
 export const QuizList = ({ quizzes }: QuizListProps) => {
 	const [confirmingId, setConfirmingId] = useState<string | null>(null)
 	const [removingId, setRemovingId] = useState<string | null>(null)
@@ -99,7 +102,7 @@ export const QuizList = ({ quizzes }: QuizListProps) => {
 								<span
 									className={cn(
 										'px-2 py-0.5 rounded-full text-xs font-medium',
-										typeColors[quiz.type],
+										typeColors[quiz.type] ?? DEFAULT_TYPE_COLOR,
 									)}
 								>
 									{quiz.type.replace('-', ' ')}

--- a/src/components/quiz/QuizList.tsx
+++ b/src/components/quiz/QuizList.tsx
@@ -105,7 +105,7 @@ export const QuizList = ({ quizzes }: QuizListProps) => {
 										typeColors[quiz.type] ?? DEFAULT_TYPE_COLOR,
 									)}
 								>
-									{quiz.type.replace('-', ' ')}
+									{quiz.type.replace(/-/g, ' ')}
 								</span>
 							</div>
 

--- a/src/hooks/useAllQuizzes.ts
+++ b/src/hooks/useAllQuizzes.ts
@@ -12,9 +12,10 @@ export const useAllQuizzes = (): { quizzes: Quiz[]; isLoading: boolean } => {
 
 	const merged = useMemo(() => {
 		const dynamic = (convexQuizzes ?? []).map(mapConvexQuiz)
-		const convexIds = new Set(dynamic.map((q) => q.id))
+		const published = dynamic.filter((q) => q.status !== 'draft')
+		const convexIds = new Set(published.map((q) => q.id))
 		const filtered = staticQuizzes.filter((q) => !convexIds.has(q.id))
-		return [...filtered, ...dynamic]
+		return [...filtered, ...published]
 	}, [convexQuizzes])
 
 	return { quizzes: merged, isLoading: convexQuizzes === undefined }

--- a/src/lib/content/mappers.ts
+++ b/src/lib/content/mappers.ts
@@ -16,6 +16,7 @@ export const mapStaticQuiz = (quiz: StaticQuiz): Quiz => ({
 	title: quiz.title,
 	questions: quiz.questions,
 	source: 'static',
+	status: 'published',
 })
 
 export const mapStaticFlashcardGroup = (
@@ -43,6 +44,7 @@ export const mapConvexQuiz = (doc: Doc<'quizContent'>): Quiz => ({
 	title: doc.title,
 	questions: doc.questions,
 	source: 'convex',
+	status: doc.status ?? 'published',
 })
 
 export const mapConvexFlashcardGroup = (

--- a/src/lib/prompts/index.ts
+++ b/src/lib/prompts/index.ts
@@ -4,6 +4,11 @@ export {
 	type ContentGenerationInput,
 } from './content-generation'
 export {
+	buildQuizGenerationPrompt,
+	QUIZ_GENERATION_SYSTEM_PROMPT,
+	type QuizGenerationInput,
+} from './quiz-generation'
+export {
 	buildQuizVerificationPrompt,
 	getSystemPrompt,
 } from './quiz-verification'

--- a/src/lib/prompts/quiz-generation.ts
+++ b/src/lib/prompts/quiz-generation.ts
@@ -1,0 +1,89 @@
+export type QuizGenerationInput = {
+	prompt: string
+	sourceText?: string
+	questionCount: number
+	difficulty?: 'easy' | 'medium' | 'hard'
+	category?: string
+	subcategory?: string
+	tags?: string[]
+	quizType?: string
+}
+
+export const QUIZ_GENERATION_SYSTEM_PROMPT = `You are an expert educator creating quiz content for a learning platform.
+
+You generate high-quality multiple-choice quizzes on any topic, from simple math to complex computer science.
+
+Output must be valid JSON only. Do not wrap JSON in markdown code fences.
+
+When metadata fields (category, subcategory, tags, difficulty, type) are not provided, infer them from the user's prompt. Choose values that accurately describe the quiz content.
+
+Difficulty calibration:
+- easy: foundational recall, single-step reasoning, straightforward definitions
+- medium: applied knowledge, multi-step reasoning, comparing related concepts
+- hard: nuanced edge cases, synthesis across topics, tricky distractors that require deep understanding
+
+Every question must have exactly 4 options (A, B, C, D) with exactly one correct answer. Explanations should teach, not just state the answer. Mistakes should explain why each wrong option is appealing.
+`
+
+export const buildQuizGenerationPrompt = (
+	input: QuizGenerationInput,
+): string => {
+	const sections: string[] = [
+		`Generate a quiz based on the following prompt:\n<prompt>\n${input.prompt}\n</prompt>`,
+		`Generate exactly ${input.questionCount} questions.`,
+	]
+
+	if (input.difficulty) {
+		sections.push(`Target difficulty: ${input.difficulty}`)
+	}
+	if (input.category) {
+		sections.push(`Category: ${input.category}`)
+	}
+	if (input.subcategory) {
+		sections.push(`Subcategory: ${input.subcategory}`)
+	}
+	if (input.tags && input.tags.length > 0) {
+		sections.push(`Tags: [${input.tags.join(', ')}]`)
+	}
+	if (input.quizType) {
+		sections.push(`Quiz type: ${input.quizType}`)
+	}
+
+	if (!input.difficulty || !input.category || !input.quizType) {
+		sections.push(
+			'For any metadata not provided above, infer appropriate values from the prompt context.',
+		)
+	}
+
+	if (input.sourceText) {
+		sections.push(
+			`Use the following source material as reference for generating questions:\n<source>\n${input.sourceText}\n</source>`,
+		)
+	}
+
+	sections.push(`Return JSON with this exact shape:
+{
+  "title": "descriptive quiz title",
+  "type": "quiz type slug (e.g. multiplication, sliding-window, vocabulary)",
+  "category": "broad category slug (e.g. math, algorithms, language)",
+  "subcategory": "specific subcategory slug (e.g. fractions, binary-search)",
+  "difficulty": "easy|medium|hard",
+  "tags": ["tag1", "tag2"],
+  "questions": [
+    {
+      "question": "question text",
+      "options": [
+        { "label": "A", "text": "option text" },
+        { "label": "B", "text": "option text" },
+        { "label": "C", "text": "option text" },
+        { "label": "D", "text": "option text" }
+      ],
+      "answer": "A",
+      "explanation": "why the correct answer is correct",
+      "mistakes": "why each wrong option is appealing"
+    }
+  ]
+}`)
+
+	return sections.join('\n\n')
+}

--- a/src/lib/prompts/quiz-generation.ts
+++ b/src/lib/prompts/quiz-generation.ts
@@ -25,11 +25,14 @@ Difficulty calibration:
 Every question must have exactly 4 options (A, B, C, D) with exactly one correct answer. Explanations should teach, not just state the answer. Mistakes should explain why each wrong option is appealing.
 `
 
+const escapeForSentinel = (text: string): string =>
+	text.replace(/<\//g, '<\\/')
+
 export const buildQuizGenerationPrompt = (
 	input: QuizGenerationInput,
 ): string => {
 	const sections: string[] = [
-		`Generate a quiz based on the following prompt:\n<prompt>\n${input.prompt}\n</prompt>`,
+		`Generate a quiz based on the following prompt:\n<prompt>\n${escapeForSentinel(input.prompt)}\n</prompt>`,
 		`Generate exactly ${input.questionCount} questions.`,
 	]
 
@@ -57,7 +60,7 @@ export const buildQuizGenerationPrompt = (
 
 	if (input.sourceText) {
 		sections.push(
-			`Use the following source material as reference for generating questions:\n<source>\n${input.sourceText}\n</source>`,
+			`Use the following source material as reference for generating questions:\n<source>\n${escapeForSentinel(input.sourceText)}\n</source>`,
 		)
 	}
 

--- a/src/lib/prompts/quiz-generation.ts
+++ b/src/lib/prompts/quiz-generation.ts
@@ -13,7 +13,7 @@ export const QUIZ_GENERATION_SYSTEM_PROMPT = `You are an expert educator creatin
 
 You generate high-quality multiple-choice quizzes on any topic, from simple math to complex computer science.
 
-Output must be valid JSON only. Do not wrap JSON in markdown code fences.
+CRITICAL: Your entire response must be a single raw JSON object. Start your response with { and end with }. No text before, no text after, no markdown, no code fences, no explanations outside the JSON.
 
 When metadata fields (category, subcategory, tags, difficulty, type) are not provided, infer them from the user's prompt. Choose values that accurately describe the quiz content.
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,10 +16,14 @@ import { Route as FlashcardsIndexRouteImport } from './routes/flashcards/index'
 import { Route as QuizzesQuizIdRouteImport } from './routes/quizzes/$quizId'
 import { Route as FlashcardsGroupIdRouteImport } from './routes/flashcards/$groupId'
 import { Route as QuizzesHistoryIndexRouteImport } from './routes/quizzes/history/index'
+import { Route as GenerateQuizIndexRouteImport } from './routes/generate/quiz/index'
 import { Route as FlashcardsHistoryIndexRouteImport } from './routes/flashcards/history/index'
 import { Route as QuizzesHistorySessionIdRouteImport } from './routes/quizzes/history/$sessionId'
+import { Route as GenerateQuizDraftsRouteImport } from './routes/generate/quiz/drafts'
 import { Route as ApiAiQuizVerifyRouteImport } from './routes/api/ai/quiz-verify'
+import { Route as ApiAiQuizGenerateRouteImport } from './routes/api/ai/quiz-generate'
 import { Route as ApiAiContentGenerateRouteImport } from './routes/api/ai/content-generate'
+import { Route as GenerateQuizPreviewContentIdRouteImport } from './routes/generate/quiz/preview/$contentId'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -56,6 +60,11 @@ const QuizzesHistoryIndexRoute = QuizzesHistoryIndexRouteImport.update({
   path: '/quizzes/history/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GenerateQuizIndexRoute = GenerateQuizIndexRouteImport.update({
+  id: '/generate/quiz/',
+  path: '/generate/quiz/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const FlashcardsHistoryIndexRoute = FlashcardsHistoryIndexRouteImport.update({
   id: '/flashcards/history/',
   path: '/flashcards/history/',
@@ -66,9 +75,19 @@ const QuizzesHistorySessionIdRoute = QuizzesHistorySessionIdRouteImport.update({
   path: '/quizzes/history/$sessionId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GenerateQuizDraftsRoute = GenerateQuizDraftsRouteImport.update({
+  id: '/generate/quiz/drafts',
+  path: '/generate/quiz/drafts',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAiQuizVerifyRoute = ApiAiQuizVerifyRouteImport.update({
   id: '/api/ai/quiz-verify',
   path: '/api/ai/quiz-verify',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAiQuizGenerateRoute = ApiAiQuizGenerateRouteImport.update({
+  id: '/api/ai/quiz-generate',
+  path: '/api/ai/quiz-generate',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiAiContentGenerateRoute = ApiAiContentGenerateRouteImport.update({
@@ -76,6 +95,12 @@ const ApiAiContentGenerateRoute = ApiAiContentGenerateRouteImport.update({
   path: '/api/ai/content-generate',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GenerateQuizPreviewContentIdRoute =
+  GenerateQuizPreviewContentIdRouteImport.update({
+    id: '/generate/quiz/preview/$contentId',
+    path: '/generate/quiz/preview/$contentId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -85,10 +110,14 @@ export interface FileRoutesByFullPath {
   '/generate/': typeof GenerateIndexRoute
   '/quizzes/': typeof QuizzesIndexRoute
   '/api/ai/content-generate': typeof ApiAiContentGenerateRoute
+  '/api/ai/quiz-generate': typeof ApiAiQuizGenerateRoute
   '/api/ai/quiz-verify': typeof ApiAiQuizVerifyRoute
+  '/generate/quiz/drafts': typeof GenerateQuizDraftsRoute
   '/quizzes/history/$sessionId': typeof QuizzesHistorySessionIdRoute
   '/flashcards/history/': typeof FlashcardsHistoryIndexRoute
+  '/generate/quiz/': typeof GenerateQuizIndexRoute
   '/quizzes/history/': typeof QuizzesHistoryIndexRoute
+  '/generate/quiz/preview/$contentId': typeof GenerateQuizPreviewContentIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -98,10 +127,14 @@ export interface FileRoutesByTo {
   '/generate': typeof GenerateIndexRoute
   '/quizzes': typeof QuizzesIndexRoute
   '/api/ai/content-generate': typeof ApiAiContentGenerateRoute
+  '/api/ai/quiz-generate': typeof ApiAiQuizGenerateRoute
   '/api/ai/quiz-verify': typeof ApiAiQuizVerifyRoute
+  '/generate/quiz/drafts': typeof GenerateQuizDraftsRoute
   '/quizzes/history/$sessionId': typeof QuizzesHistorySessionIdRoute
   '/flashcards/history': typeof FlashcardsHistoryIndexRoute
+  '/generate/quiz': typeof GenerateQuizIndexRoute
   '/quizzes/history': typeof QuizzesHistoryIndexRoute
+  '/generate/quiz/preview/$contentId': typeof GenerateQuizPreviewContentIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -112,10 +145,14 @@ export interface FileRoutesById {
   '/generate/': typeof GenerateIndexRoute
   '/quizzes/': typeof QuizzesIndexRoute
   '/api/ai/content-generate': typeof ApiAiContentGenerateRoute
+  '/api/ai/quiz-generate': typeof ApiAiQuizGenerateRoute
   '/api/ai/quiz-verify': typeof ApiAiQuizVerifyRoute
+  '/generate/quiz/drafts': typeof GenerateQuizDraftsRoute
   '/quizzes/history/$sessionId': typeof QuizzesHistorySessionIdRoute
   '/flashcards/history/': typeof FlashcardsHistoryIndexRoute
+  '/generate/quiz/': typeof GenerateQuizIndexRoute
   '/quizzes/history/': typeof QuizzesHistoryIndexRoute
+  '/generate/quiz/preview/$contentId': typeof GenerateQuizPreviewContentIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -127,10 +164,14 @@ export interface FileRouteTypes {
     | '/generate/'
     | '/quizzes/'
     | '/api/ai/content-generate'
+    | '/api/ai/quiz-generate'
     | '/api/ai/quiz-verify'
+    | '/generate/quiz/drafts'
     | '/quizzes/history/$sessionId'
     | '/flashcards/history/'
+    | '/generate/quiz/'
     | '/quizzes/history/'
+    | '/generate/quiz/preview/$contentId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -140,10 +181,14 @@ export interface FileRouteTypes {
     | '/generate'
     | '/quizzes'
     | '/api/ai/content-generate'
+    | '/api/ai/quiz-generate'
     | '/api/ai/quiz-verify'
+    | '/generate/quiz/drafts'
     | '/quizzes/history/$sessionId'
     | '/flashcards/history'
+    | '/generate/quiz'
     | '/quizzes/history'
+    | '/generate/quiz/preview/$contentId'
   id:
     | '__root__'
     | '/'
@@ -153,10 +198,14 @@ export interface FileRouteTypes {
     | '/generate/'
     | '/quizzes/'
     | '/api/ai/content-generate'
+    | '/api/ai/quiz-generate'
     | '/api/ai/quiz-verify'
+    | '/generate/quiz/drafts'
     | '/quizzes/history/$sessionId'
     | '/flashcards/history/'
+    | '/generate/quiz/'
     | '/quizzes/history/'
+    | '/generate/quiz/preview/$contentId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -167,10 +216,14 @@ export interface RootRouteChildren {
   GenerateIndexRoute: typeof GenerateIndexRoute
   QuizzesIndexRoute: typeof QuizzesIndexRoute
   ApiAiContentGenerateRoute: typeof ApiAiContentGenerateRoute
+  ApiAiQuizGenerateRoute: typeof ApiAiQuizGenerateRoute
   ApiAiQuizVerifyRoute: typeof ApiAiQuizVerifyRoute
+  GenerateQuizDraftsRoute: typeof GenerateQuizDraftsRoute
   QuizzesHistorySessionIdRoute: typeof QuizzesHistorySessionIdRoute
   FlashcardsHistoryIndexRoute: typeof FlashcardsHistoryIndexRoute
+  GenerateQuizIndexRoute: typeof GenerateQuizIndexRoute
   QuizzesHistoryIndexRoute: typeof QuizzesHistoryIndexRoute
+  GenerateQuizPreviewContentIdRoute: typeof GenerateQuizPreviewContentIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -224,6 +277,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof QuizzesHistoryIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/generate/quiz/': {
+      id: '/generate/quiz/'
+      path: '/generate/quiz'
+      fullPath: '/generate/quiz/'
+      preLoaderRoute: typeof GenerateQuizIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/flashcards/history/': {
       id: '/flashcards/history/'
       path: '/flashcards/history'
@@ -238,6 +298,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof QuizzesHistorySessionIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/generate/quiz/drafts': {
+      id: '/generate/quiz/drafts'
+      path: '/generate/quiz/drafts'
+      fullPath: '/generate/quiz/drafts'
+      preLoaderRoute: typeof GenerateQuizDraftsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/ai/quiz-verify': {
       id: '/api/ai/quiz-verify'
       path: '/api/ai/quiz-verify'
@@ -245,11 +312,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAiQuizVerifyRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/ai/quiz-generate': {
+      id: '/api/ai/quiz-generate'
+      path: '/api/ai/quiz-generate'
+      fullPath: '/api/ai/quiz-generate'
+      preLoaderRoute: typeof ApiAiQuizGenerateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/ai/content-generate': {
       id: '/api/ai/content-generate'
       path: '/api/ai/content-generate'
       fullPath: '/api/ai/content-generate'
       preLoaderRoute: typeof ApiAiContentGenerateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/generate/quiz/preview/$contentId': {
+      id: '/generate/quiz/preview/$contentId'
+      path: '/generate/quiz/preview/$contentId'
+      fullPath: '/generate/quiz/preview/$contentId'
+      preLoaderRoute: typeof GenerateQuizPreviewContentIdRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -263,10 +344,14 @@ const rootRouteChildren: RootRouteChildren = {
   GenerateIndexRoute: GenerateIndexRoute,
   QuizzesIndexRoute: QuizzesIndexRoute,
   ApiAiContentGenerateRoute: ApiAiContentGenerateRoute,
+  ApiAiQuizGenerateRoute: ApiAiQuizGenerateRoute,
   ApiAiQuizVerifyRoute: ApiAiQuizVerifyRoute,
+  GenerateQuizDraftsRoute: GenerateQuizDraftsRoute,
   QuizzesHistorySessionIdRoute: QuizzesHistorySessionIdRoute,
   FlashcardsHistoryIndexRoute: FlashcardsHistoryIndexRoute,
+  GenerateQuizIndexRoute: GenerateQuizIndexRoute,
   QuizzesHistoryIndexRoute: QuizzesHistoryIndexRoute,
+  GenerateQuizPreviewContentIdRoute: GenerateQuizPreviewContentIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/ai/quiz-generate.ts
+++ b/src/routes/api/ai/quiz-generate.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/tanstackstart-react'
 import { createClerkClient } from '@clerk/backend'
 import { chat } from '@tanstack/ai'
 import { anthropicText } from '@tanstack/ai-anthropic'
@@ -36,16 +37,23 @@ const OutputSchema = z.object({
 	tags: z.array(z.string()),
 	questions: z
 		.array(
-			z.object({
-				question: z.string().min(1),
-				options: z
-					.array(z.object({ label: z.string(), text: z.string() }))
-					.min(4)
-					.max(4),
-				answer: z.string().min(1),
-				explanation: z.string().min(1),
-				mistakes: z.string().optional(),
-			}),
+			z
+				.object({
+					question: z.string().min(1),
+					options: z
+						.array(z.object({ label: z.string().min(1), text: z.string().min(1) }))
+						.length(4)
+						.refine(
+							(opts) => new Set(opts.map((o) => o.label)).size === 4,
+							{ message: 'Option labels must be unique' },
+						),
+					answer: z.string().min(1),
+					explanation: z.string().min(1),
+					mistakes: z.string().optional(),
+				})
+				.refine((q) => q.options.some((o) => o.label === q.answer), {
+					message: 'Answer must match one of the option labels',
+				}),
 		)
 		.min(1),
 })
@@ -60,40 +68,46 @@ export const Route = createFileRoute('/api/ai/quiz-generate')({
 	server: {
 		handlers: {
 			POST: async ({ request }) => {
-				const { isAuthenticated } = await clerk.authenticateRequest(request)
-				if (!isAuthenticated) return jsonError('Unauthorized', 401)
+				return await Sentry.startSpan({ name: 'Quiz generation' }, async () => {
+					const { isAuthenticated } = await clerk.authenticateRequest(request)
+					if (!isAuthenticated) return jsonError('Unauthorized', 401)
 
-				let body: unknown
-				try {
-					body = await request.json()
-				} catch {
-					return jsonError('Malformed JSON body', 400)
-				}
+					let body: unknown
+					try {
+						body = await request.json()
+					} catch {
+						return jsonError('Malformed JSON body', 400)
+					}
 
-				const parsedInput = InputSchema.safeParse(body)
-				if (!parsedInput.success) {
-					return jsonError('Invalid quiz generation request', 400)
-				}
+					const parsedInput = InputSchema.safeParse(body)
+					if (!parsedInput.success) {
+						return jsonError('Invalid quiz generation request', 400)
+					}
 
-				const adapter = anthropicText(MODEL as 'claude-sonnet-4')
-				const prompt = buildQuizGenerationPrompt(parsedInput.data)
+					const adapter = anthropicText(MODEL as 'claude-sonnet-4')
+					const prompt = buildQuizGenerationPrompt(parsedInput.data)
 
-				let result: z.infer<typeof OutputSchema>
-				try {
-					result = await chat({
-						adapter,
-						messages: [{ role: 'user', content: prompt }],
-						systemPrompts: [QUIZ_GENERATION_SYSTEM_PROMPT],
-						maxTokens: MAX_TOKENS,
-						outputSchema: OutputSchema,
+					let result: z.infer<typeof OutputSchema>
+					try {
+						result = await chat({
+							adapter,
+							messages: [{ role: 'user', content: prompt }],
+							systemPrompts: [QUIZ_GENERATION_SYSTEM_PROMPT],
+							maxTokens: MAX_TOKENS,
+							outputSchema: OutputSchema,
+						})
+					} catch {
+						return jsonError('Quiz generation failed', 500)
+					}
+
+					if (result.questions.length !== parsedInput.data.questionCount) {
+						return jsonError('Generated quiz has incorrect question count', 500)
+					}
+
+					return new Response(JSON.stringify(result), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
 					})
-				} catch {
-					return jsonError('Quiz generation failed', 500)
-				}
-
-				return new Response(JSON.stringify(result), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
 				})
 			},
 		},

--- a/src/routes/api/ai/quiz-generate.ts
+++ b/src/routes/api/ai/quiz-generate.ts
@@ -1,6 +1,5 @@
-import * as Sentry from '@sentry/tanstackstart-react'
 import { createClerkClient } from '@clerk/backend'
-import { chat } from '@tanstack/ai'
+import { chat, toServerSentEventsResponse } from '@tanstack/ai'
 import { anthropicText } from '@tanstack/ai-anthropic'
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
@@ -28,36 +27,6 @@ const InputSchema = z.object({
 	quizType: z.string().optional(),
 })
 
-const OutputSchema = z.object({
-	title: z.string().min(1),
-	type: z.string().min(1),
-	category: z.string().min(1),
-	subcategory: z.string().min(1),
-	difficulty: z.enum(['easy', 'medium', 'hard']),
-	tags: z.array(z.string()),
-	questions: z
-		.array(
-			z
-				.object({
-					question: z.string().min(1),
-					options: z
-						.array(z.object({ label: z.string().min(1), text: z.string().min(1) }))
-						.length(4)
-						.refine(
-							(opts) => new Set(opts.map((o) => o.label)).size === 4,
-							{ message: 'Option labels must be unique' },
-						),
-					answer: z.string().min(1),
-					explanation: z.string().min(1),
-					mistakes: z.string().optional(),
-				})
-				.refine((q) => q.options.some((o) => o.label === q.answer), {
-					message: 'Answer must match one of the option labels',
-				}),
-		)
-		.min(1),
-})
-
 const jsonError = (message: string, status: number) =>
 	new Response(JSON.stringify({ error: message }), {
 		status,
@@ -68,47 +37,32 @@ export const Route = createFileRoute('/api/ai/quiz-generate')({
 	server: {
 		handlers: {
 			POST: async ({ request }) => {
-				return await Sentry.startSpan({ name: 'Quiz generation' }, async () => {
-					const { isAuthenticated } = await clerk.authenticateRequest(request)
-					if (!isAuthenticated) return jsonError('Unauthorized', 401)
+				const { isAuthenticated } = await clerk.authenticateRequest(request)
+				if (!isAuthenticated) return jsonError('Unauthorized', 401)
 
-					let body: unknown
-					try {
-						body = await request.json()
-					} catch {
-						return jsonError('Malformed JSON body', 400)
-					}
+				let body: unknown
+				try {
+					body = await request.json()
+				} catch {
+					return jsonError('Malformed JSON body', 400)
+				}
 
-					const parsedInput = InputSchema.safeParse(body)
-					if (!parsedInput.success) {
-						return jsonError('Invalid quiz generation request', 400)
-					}
+				const parsedInput = InputSchema.safeParse(body)
+				if (!parsedInput.success) {
+					return jsonError('Invalid quiz generation request', 400)
+				}
 
-					const adapter = anthropicText(MODEL as 'claude-sonnet-4')
-					const prompt = buildQuizGenerationPrompt(parsedInput.data)
+				const prompt = buildQuizGenerationPrompt(parsedInput.data)
+				const adapter = anthropicText(MODEL as 'claude-sonnet-4')
 
-					let result: z.infer<typeof OutputSchema>
-					try {
-						result = await chat({
-							adapter,
-							messages: [{ role: 'user', content: prompt }],
-							systemPrompts: [QUIZ_GENERATION_SYSTEM_PROMPT],
-							maxTokens: MAX_TOKENS,
-							outputSchema: OutputSchema,
-						})
-					} catch {
-						return jsonError('Quiz generation failed', 500)
-					}
-
-					if (result.questions.length !== parsedInput.data.questionCount) {
-						return jsonError('Generated quiz has incorrect question count', 500)
-					}
-
-					return new Response(JSON.stringify(result), {
-						status: 200,
-						headers: { 'Content-Type': 'application/json' },
-					})
+				const stream = chat({
+					adapter,
+					messages: [{ role: 'user', content: prompt }],
+					systemPrompts: [QUIZ_GENERATION_SYSTEM_PROMPT],
+					maxTokens: MAX_TOKENS,
 				})
+
+				return toServerSentEventsResponse(stream)
 			},
 		},
 	},

--- a/src/routes/api/ai/quiz-generate.ts
+++ b/src/routes/api/ai/quiz-generate.ts
@@ -37,6 +37,8 @@ export const Route = createFileRoute('/api/ai/quiz-generate')({
 	server: {
 		handlers: {
 			POST: async ({ request }) => {
+				console.log('[quiz-generate] handler invoked')
+
 				const { isAuthenticated } = await clerk.authenticateRequest(request)
 				if (!isAuthenticated) return jsonError('Unauthorized', 401)
 
@@ -51,6 +53,10 @@ export const Route = createFileRoute('/api/ai/quiz-generate')({
 				if (!parsedInput.success) {
 					return jsonError('Invalid quiz generation request', 400)
 				}
+
+				console.log(
+					`[quiz-generate] starting generation, questionCount=${parsedInput.data.questionCount}`,
+				)
 
 				const prompt = buildQuizGenerationPrompt(parsedInput.data)
 				const adapter = anthropicText(MODEL as 'claude-sonnet-4')

--- a/src/routes/api/ai/quiz-generate.ts
+++ b/src/routes/api/ai/quiz-generate.ts
@@ -1,0 +1,101 @@
+import { createClerkClient } from '@clerk/backend'
+import { chat } from '@tanstack/ai'
+import { anthropicText } from '@tanstack/ai-anthropic'
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+import {
+	buildQuizGenerationPrompt,
+	QUIZ_GENERATION_SYSTEM_PROMPT,
+} from '@/lib/prompts'
+
+const MODEL = 'claude-sonnet-4-20250514' as const
+const MAX_TOKENS = 8192
+
+const clerk = createClerkClient({
+	secretKey: process.env.CLERK_SECRET_KEY,
+	publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+})
+
+const InputSchema = z.object({
+	prompt: z.string().min(1),
+	sourceText: z.string().optional(),
+	questionCount: z.number().int().min(1).max(25).default(10),
+	difficulty: z.enum(['easy', 'medium', 'hard']).optional(),
+	category: z.string().optional(),
+	subcategory: z.string().optional(),
+	tags: z.array(z.string()).optional(),
+	quizType: z.string().optional(),
+})
+
+const OutputSchema = z.object({
+	title: z.string().min(1),
+	type: z.string().min(1),
+	category: z.string().min(1),
+	subcategory: z.string().min(1),
+	difficulty: z.enum(['easy', 'medium', 'hard']),
+	tags: z.array(z.string()),
+	questions: z
+		.array(
+			z.object({
+				question: z.string().min(1),
+				options: z
+					.array(z.object({ label: z.string(), text: z.string() }))
+					.min(4)
+					.max(4),
+				answer: z.string().min(1),
+				explanation: z.string().min(1),
+				mistakes: z.string().optional(),
+			}),
+		)
+		.min(1),
+})
+
+const jsonError = (message: string, status: number) =>
+	new Response(JSON.stringify({ error: message }), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	})
+
+export const Route = createFileRoute('/api/ai/quiz-generate')({
+	server: {
+		handlers: {
+			POST: async ({ request }) => {
+				const { isAuthenticated } = await clerk.authenticateRequest(request)
+				if (!isAuthenticated) return jsonError('Unauthorized', 401)
+
+				let body: unknown
+				try {
+					body = await request.json()
+				} catch {
+					return jsonError('Malformed JSON body', 400)
+				}
+
+				const parsedInput = InputSchema.safeParse(body)
+				if (!parsedInput.success) {
+					return jsonError('Invalid quiz generation request', 400)
+				}
+
+				const adapter = anthropicText(MODEL as 'claude-sonnet-4')
+				const prompt = buildQuizGenerationPrompt(parsedInput.data)
+
+				let result: z.infer<typeof OutputSchema>
+				try {
+					result = await chat({
+						adapter,
+						messages: [{ role: 'user', content: prompt }],
+						systemPrompts: [QUIZ_GENERATION_SYSTEM_PROMPT],
+						maxTokens: MAX_TOKENS,
+						outputSchema: OutputSchema,
+					})
+				} catch {
+					return jsonError('Quiz generation failed', 500)
+				}
+
+				return new Response(JSON.stringify(result), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				})
+			},
+		},
+	},
+})

--- a/src/routes/generate/quiz/drafts.tsx
+++ b/src/routes/generate/quiz/drafts.tsx
@@ -1,0 +1,113 @@
+import { SignedIn, SignedOut, SignInButton } from '@clerk/clerk-react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useQuery } from 'convex/react'
+import { FileText, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { api } from '../../../../convex/_generated/api'
+
+export const Route = createFileRoute('/generate/quiz/drafts')({
+	component: QuizDraftsPage,
+})
+
+const difficultyColors: Record<string, string> = {
+	easy: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+	medium:
+		'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+	hard: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+}
+
+function QuizDraftsPage() {
+	return (
+		<div className="container mx-auto py-8 px-4 max-w-3xl">
+			<SignedOut>
+				<div className="flex flex-col items-center gap-4 py-12">
+					<p className="text-muted-foreground">Sign in to view your drafts.</p>
+					<SignInButton mode="modal">
+						<Button>Sign In</Button>
+					</SignInButton>
+				</div>
+			</SignedOut>
+			<SignedIn>
+				<DraftsList />
+			</SignedIn>
+		</div>
+	)
+}
+
+function DraftsList() {
+	const drafts = useQuery(api.quizContent.listDrafts)
+
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex items-center justify-between">
+				<div className="flex flex-col gap-1">
+					<h1 className="text-2xl font-bold">Quiz Drafts</h1>
+					<p className="text-muted-foreground">
+						Review and publish your generated quizzes.
+					</p>
+				</div>
+				<Link to="/generate/quiz">
+					<Button variant="outline" size="sm">
+						<Plus size={16} className="mr-1" />
+						New Quiz
+					</Button>
+				</Link>
+			</div>
+
+			{drafts === undefined && (
+				<p className="text-muted-foreground">Loading drafts...</p>
+			)}
+
+			{drafts && drafts.length === 0 && (
+				<div className="flex flex-col items-center gap-4 py-12 text-center">
+					<FileText size={48} className="text-muted-foreground/40" />
+					<p className="text-muted-foreground">
+						No drafts yet. Generate a quiz to get started.
+					</p>
+					<Link to="/generate/quiz">
+						<Button>Generate Quiz</Button>
+					</Link>
+				</div>
+			)}
+
+			{drafts && drafts.length > 0 && (
+				<div className="grid grid-cols-1 gap-3">
+					{drafts.map((draft) => (
+						<Link
+							key={draft.contentId}
+							to="/generate/quiz/preview/$contentId"
+							params={{ contentId: draft.contentId }}
+							className={cn(
+								'flex items-center justify-between gap-4 p-4 rounded-lg border border-border',
+								'bg-card hover:shadow-md hover:border-primary/30 transition-all',
+							)}
+						>
+							<div className="flex flex-col gap-1 min-w-0">
+								<h2 className="font-semibold truncate">{draft.title}</h2>
+								<div className="flex items-center gap-2 text-sm text-muted-foreground">
+									<span>{draft.questions.length} questions</span>
+									<span>·</span>
+									<span>{draft.type.replace(/-/g, ' ')}</span>
+								</div>
+							</div>
+							<div className="flex items-center gap-2 shrink-0">
+								<span
+									className={cn(
+										'px-2 py-0.5 rounded-full text-xs font-medium capitalize',
+										difficultyColors[draft.difficulty],
+									)}
+								>
+									{draft.difficulty}
+								</span>
+								<span className="px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200 text-xs font-medium">
+									Draft
+								</span>
+							</div>
+						</Link>
+					))}
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/routes/generate/quiz/drafts.tsx
+++ b/src/routes/generate/quiz/drafts.tsx
@@ -47,12 +47,12 @@ function DraftsList() {
 						Review and publish your generated quizzes.
 					</p>
 				</div>
-				<Link to="/generate/quiz">
-					<Button variant="outline" size="sm">
+				<Button asChild variant="outline" size="sm">
+					<Link to="/generate/quiz" search={{ prompt: '' }}>
 						<Plus size={16} className="mr-1" />
 						New Quiz
-					</Button>
-				</Link>
+					</Link>
+				</Button>
 			</div>
 
 			{drafts === undefined && (
@@ -65,9 +65,9 @@ function DraftsList() {
 					<p className="text-muted-foreground">
 						No drafts yet. Generate a quiz to get started.
 					</p>
-					<Link to="/generate/quiz">
-						<Button>Generate Quiz</Button>
-					</Link>
+					<Button asChild>
+						<Link to="/generate/quiz" search={{ prompt: '' }}>Generate Quiz</Link>
+					</Button>
 				</div>
 			)}
 

--- a/src/routes/generate/quiz/index.tsx
+++ b/src/routes/generate/quiz/index.tsx
@@ -38,6 +38,7 @@ const accumulateSseText = async (response: Response): Promise<string> => {
 	const decoder = new TextDecoder()
 	let buffer = ''
 	let lastContent = ''
+	let receivedDone = false
 
 	while (true) {
 		const { done, value } = await reader.read()
@@ -51,20 +52,35 @@ const accumulateSseText = async (response: Response): Promise<string> => {
 			for (const line of part.split('\n')) {
 				if (!line.startsWith('data: ')) continue
 				const data = line.slice(6)
-				if (data === '[DONE]') return lastContent
+				if (data === '[DONE]') {
+					receivedDone = true
+					return lastContent
+				}
 				try {
 					const event = JSON.parse(data) as {
 						type?: string
 						content?: string
+						error?: { message?: string }
 					}
 					if (event.type === 'content' && typeof event.content === 'string') {
 						lastContent = event.content
+					} else if (event.type === 'error') {
+						throw new Error(
+							event.error?.message ?? 'Generation failed — please try again',
+						)
 					}
-				} catch {
-					// skip malformed events
+				} catch (e) {
+					if (e instanceof SyntaxError) continue
+					throw e
 				}
 			}
 		}
+	}
+
+	if (!receivedDone) {
+		throw new Error(
+			'Generation was cut off before completing — the quiz may be too large, please try fewer questions',
+		)
 	}
 
 	return lastContent

--- a/src/routes/generate/quiz/index.tsx
+++ b/src/routes/generate/quiz/index.tsx
@@ -1,0 +1,312 @@
+import { SignedIn, SignedOut, SignInButton } from '@clerk/clerk-react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useMutation } from 'convex/react'
+import { ChevronDown, ChevronUp, Sparkles } from 'lucide-react'
+import { useId, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { extractTextFromPdf } from '@/lib/pdf/extract-text'
+import { api } from '../../../../convex/_generated/api'
+
+export const Route = createFileRoute('/generate/quiz/')({
+	component: QuizGeneratorPage,
+})
+
+type Difficulty = 'easy' | 'medium' | 'hard'
+
+const slugify = (value: string) =>
+	value
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/(^-|-$)/g, '')
+
+function QuizGeneratorPage() {
+	return (
+		<div className="container mx-auto py-8 px-4 max-w-2xl">
+			<SignedOut>
+				<div className="flex flex-col items-center gap-4 py-12">
+					<p className="text-muted-foreground">Sign in to generate quizzes.</p>
+					<SignInButton mode="modal">
+						<Button>Sign In</Button>
+					</SignInButton>
+				</div>
+			</SignedOut>
+			<SignedIn>
+				<QuizGenerateForm />
+			</SignedIn>
+		</div>
+	)
+}
+
+function QuizGenerateForm() {
+	const navigate = useNavigate()
+	const promptId = useId()
+	const sourceTextId = useId()
+	const sourceFileId = useId()
+
+	const [prompt, setPrompt] = useState('')
+	const [sourceText, setSourceText] = useState('')
+	const [questionCount, setQuestionCount] = useState(10)
+	const [difficulty, setDifficulty] = useState<Difficulty | ''>('')
+	const [quizType, setQuizType] = useState('')
+	const [category, setCategory] = useState('')
+	const [subcategory, setSubcategory] = useState('')
+	const [tags, setTags] = useState('')
+	const [showAdvanced, setShowAdvanced] = useState(false)
+	const [isGenerating, setIsGenerating] = useState(false)
+	const [isExtracting, setIsExtracting] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	const createQuiz = useMutation(api.quizContent.create)
+
+	const handleSourceFile = async (file: File) => {
+		setIsExtracting(true)
+		try {
+			if (
+				file.type === 'application/pdf' ||
+				file.name.toLowerCase().endsWith('.pdf')
+			) {
+				setSourceText(await extractTextFromPdf(file))
+				return
+			}
+			setSourceText(await file.text())
+		} catch {
+			setError('Could not read this file.')
+		} finally {
+			setIsExtracting(false)
+		}
+	}
+
+	const handleGenerate = async () => {
+		setError(null)
+		if (!prompt.trim()) {
+			setError('Please enter a prompt describing the quiz you want.')
+			return
+		}
+
+		setIsGenerating(true)
+
+		try {
+			const parsedTags = tags
+				.split(',')
+				.map((t) => t.trim())
+				.filter(Boolean)
+
+			const body: Record<string, unknown> = {
+				prompt: prompt.trim(),
+				questionCount,
+			}
+			if (sourceText.trim()) body.sourceText = sourceText.trim()
+			if (difficulty) body.difficulty = difficulty
+			if (category.trim()) body.category = slugify(category)
+			if (subcategory.trim()) body.subcategory = slugify(subcategory)
+			if (parsedTags.length > 0) body.tags = parsedTags.map(slugify)
+			if (quizType.trim()) body.quizType = slugify(quizType)
+
+			const res = await fetch('/api/ai/quiz-generate', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body),
+			})
+
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}))
+				throw new Error(
+					(data as { error?: string }).error ?? 'Generation failed',
+				)
+			}
+
+			const quiz = await res.json()
+			const contentId = `${slugify(quiz.type)}-${slugify(quiz.subcategory)}-${Date.now()}`
+
+			await createQuiz({
+				contentId,
+				type: quiz.type,
+				category: quiz.category,
+				subcategory: quiz.subcategory,
+				difficulty: quiz.difficulty,
+				tags: quiz.tags,
+				version: '1.0.0',
+				title: quiz.title,
+				questions: quiz.questions,
+				status: 'draft',
+				sourcePrompt: prompt.trim(),
+			})
+
+			navigate({
+				to: '/generate/quiz/preview/$contentId',
+				params: { contentId },
+			})
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Generation failed')
+		} finally {
+			setIsGenerating(false)
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex flex-col gap-2">
+				<h1 className="text-2xl font-bold">Generate Quiz</h1>
+				<p className="text-muted-foreground">
+					Describe the quiz you want and we&apos;ll generate it. Optionally
+					provide source material and settings.
+				</p>
+			</div>
+
+			<div className="flex flex-col gap-4">
+				<div className="flex flex-col gap-2">
+					<Label htmlFor={promptId}>Prompt</Label>
+					<Textarea
+						id={promptId}
+						value={prompt}
+						onChange={(e) => setPrompt(e.target.value)}
+						placeholder='e.g. "Basic multiplication for 3rd graders" or "DSA sliding window patterns with edge cases"'
+						rows={3}
+						disabled={isGenerating}
+					/>
+				</div>
+
+				<div className="flex items-center gap-2">
+					<Label>Questions</Label>
+					<Input
+						type="number"
+						min={1}
+						max={25}
+						value={questionCount}
+						onChange={(e) =>
+							setQuestionCount(
+								Math.max(1, Math.min(25, Number(e.target.value))),
+							)
+						}
+						className="w-20"
+						disabled={isGenerating}
+					/>
+				</div>
+
+				<button
+					type="button"
+					onClick={() => setShowAdvanced(!showAdvanced)}
+					className="flex items-center gap-1 text-sm text-muted-foreground hover:text-primary transition-colors self-start"
+				>
+					{showAdvanced ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+					Advanced Settings
+				</button>
+
+				{showAdvanced && (
+					<div className="flex flex-col gap-4 pl-4 border-l-2 border-border">
+						<div className="flex flex-col gap-2">
+							<Label>Difficulty</Label>
+							<Select
+								value={difficulty}
+								onValueChange={(v) => setDifficulty(v as Difficulty | '')}
+								disabled={isGenerating}
+							>
+								<SelectTrigger className="w-48">
+									<SelectValue placeholder="Let AI decide" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="easy">Easy</SelectItem>
+									<SelectItem value="medium">Medium</SelectItem>
+									<SelectItem value="hard">Hard</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="grid grid-cols-2 gap-4">
+							<div className="flex flex-col gap-2">
+								<Label>Quiz Type</Label>
+								<Input
+									value={quizType}
+									onChange={(e) => setQuizType(e.target.value)}
+									placeholder="e.g. multiplication, sliding-window"
+									disabled={isGenerating}
+								/>
+							</div>
+							<div className="flex flex-col gap-2">
+								<Label>Category</Label>
+								<Input
+									value={category}
+									onChange={(e) => setCategory(e.target.value)}
+									placeholder="e.g. math, algorithms"
+									disabled={isGenerating}
+								/>
+							</div>
+						</div>
+
+						<div className="grid grid-cols-2 gap-4">
+							<div className="flex flex-col gap-2">
+								<Label>Subcategory</Label>
+								<Input
+									value={subcategory}
+									onChange={(e) => setSubcategory(e.target.value)}
+									placeholder="e.g. fractions, binary-search"
+									disabled={isGenerating}
+								/>
+							</div>
+							<div className="flex flex-col gap-2">
+								<Label>Tags</Label>
+								<Input
+									value={tags}
+									onChange={(e) => setTags(e.target.value)}
+									placeholder="comma-separated"
+									disabled={isGenerating}
+								/>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-2">
+							<Label htmlFor={sourceFileId}>Source Material (optional)</Label>
+							<input
+								id={sourceFileId}
+								type="file"
+								accept=".pdf,.md,.txt,.text"
+								disabled={isExtracting || isGenerating}
+								onChange={(e) => {
+									const file = e.target.files?.[0]
+									if (file) void handleSourceFile(file)
+								}}
+								className="text-sm"
+							/>
+							<Textarea
+								id={sourceTextId}
+								value={sourceText}
+								onChange={(e) => setSourceText(e.target.value)}
+								placeholder="Paste source text here, or upload a file above..."
+								rows={4}
+								disabled={isExtracting || isGenerating}
+							/>
+						</div>
+					</div>
+				)}
+
+				{error && <p className="text-sm text-destructive">{error}</p>}
+
+				<Button
+					onClick={() => void handleGenerate()}
+					disabled={isGenerating || !prompt.trim()}
+					className="self-start"
+				>
+					{isGenerating ? (
+						'Generating...'
+					) : (
+						<>
+							<Sparkles size={16} className="mr-2" />
+							Generate Quiz
+						</>
+					)}
+				</Button>
+			</div>
+		</div>
+	)
+}

--- a/src/routes/generate/quiz/index.tsx
+++ b/src/routes/generate/quiz/index.tsx
@@ -18,6 +18,9 @@ import { extractTextFromPdf } from '@/lib/pdf/extract-text'
 import { api } from '../../../../convex/_generated/api'
 
 export const Route = createFileRoute('/generate/quiz/')({
+	validateSearch: (search: Record<string, unknown>) => ({
+		prompt: typeof search.prompt === 'string' ? search.prompt : '',
+	}),
 	component: QuizGeneratorPage,
 })
 
@@ -50,11 +53,12 @@ function QuizGeneratorPage() {
 
 function QuizGenerateForm() {
 	const navigate = useNavigate()
+	const { prompt: initialPrompt } = Route.useSearch()
 	const promptId = useId()
 	const sourceTextId = useId()
 	const sourceFileId = useId()
 
-	const [prompt, setPrompt] = useState('')
+	const [prompt, setPrompt] = useState(initialPrompt)
 	const [sourceText, setSourceText] = useState('')
 	const [questionCount, setQuestionCount] = useState(10)
 	const [difficulty, setDifficulty] = useState<Difficulty | ''>('')
@@ -139,7 +143,6 @@ function QuizGenerateForm() {
 				version: '1.0.0',
 				title: quiz.title,
 				questions: quiz.questions,
-				status: 'draft',
 				sourcePrompt: prompt.trim(),
 			})
 
@@ -216,6 +219,7 @@ function QuizGenerateForm() {
 									<SelectValue placeholder="Let AI decide" />
 								</SelectTrigger>
 								<SelectContent>
+									<SelectItem value="">Let AI decide</SelectItem>
 									<SelectItem value="easy">Easy</SelectItem>
 									<SelectItem value="medium">Medium</SelectItem>
 									<SelectItem value="hard">Hard</SelectItem>

--- a/src/routes/generate/quiz/index.tsx
+++ b/src/routes/generate/quiz/index.tsx
@@ -33,6 +33,50 @@ const slugify = (value: string) =>
 		.replace(/[^a-z0-9]+/g, '-')
 		.replace(/(^-|-$)/g, '')
 
+const accumulateSseText = async (response: Response): Promise<string> => {
+	const reader = response.body!.getReader()
+	const decoder = new TextDecoder()
+	let buffer = ''
+	let lastContent = ''
+
+	while (true) {
+		const { done, value } = await reader.read()
+		if (done) break
+
+		buffer += decoder.decode(value, { stream: true })
+		const parts = buffer.split('\n\n')
+		buffer = parts.pop() ?? ''
+
+		for (const part of parts) {
+			for (const line of part.split('\n')) {
+				if (!line.startsWith('data: ')) continue
+				const data = line.slice(6)
+				if (data === '[DONE]') return lastContent
+				try {
+					const event = JSON.parse(data) as {
+						type?: string
+						content?: string
+					}
+					if (event.type === 'content' && typeof event.content === 'string') {
+						lastContent = event.content
+					}
+				} catch {
+					// skip malformed events
+				}
+			}
+		}
+	}
+
+	return lastContent
+}
+
+const extractJson = (text: string): string => {
+	const start = text.indexOf('{')
+	const end = text.lastIndexOf('}')
+	if (start === -1 || end === -1 || end < start) return text
+	return text.slice(start, end + 1)
+}
+
 function QuizGeneratorPage() {
 	return (
 		<div className="container mx-auto py-8 px-4 max-w-2xl">
@@ -130,7 +174,28 @@ function QuizGenerateForm() {
 				)
 			}
 
-			const quiz = await res.json()
+			const rawText = await accumulateSseText(res)
+			const cleanedJson = extractJson(rawText.trim())
+			let quiz: {
+				type: string
+				subcategory: string
+				category: string
+				difficulty: 'easy' | 'medium' | 'hard'
+				tags: string[]
+				title: string
+				questions: Array<{
+					question: string
+					options: { label: string; text: string }[]
+					answer: string
+					explanation: string
+					mistakes?: string
+				}>
+			}
+			try {
+				quiz = JSON.parse(cleanedJson)
+			} catch {
+				throw new Error('Failed to parse generated quiz — please try again')
+			}
 			const contentId = `${slugify(quiz.type)}-${slugify(quiz.subcategory)}-${Date.now()}`
 
 			await createQuiz({

--- a/src/routes/generate/quiz/index.tsx
+++ b/src/routes/generate/quiz/index.tsx
@@ -1,6 +1,6 @@
 import { SignedIn, SignedOut, SignInButton } from '@clerk/clerk-react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useMutation } from 'convex/react'
+import { useAction } from 'convex/react'
 import { ChevronDown, ChevronUp, Sparkles } from 'lucide-react'
 import { useId, useState } from 'react'
 import { Button } from '@/components/ui/button'
@@ -32,66 +32,6 @@ const slugify = (value: string) =>
 		.trim()
 		.replace(/[^a-z0-9]+/g, '-')
 		.replace(/(^-|-$)/g, '')
-
-const accumulateSseText = async (response: Response): Promise<string> => {
-	const reader = response.body!.getReader()
-	const decoder = new TextDecoder()
-	let buffer = ''
-	let lastContent = ''
-	let receivedDone = false
-
-	while (true) {
-		const { done, value } = await reader.read()
-		if (done) break
-
-		buffer += decoder.decode(value, { stream: true })
-		const parts = buffer.split('\n\n')
-		buffer = parts.pop() ?? ''
-
-		for (const part of parts) {
-			for (const line of part.split('\n')) {
-				if (!line.startsWith('data: ')) continue
-				const data = line.slice(6)
-				if (data === '[DONE]') {
-					receivedDone = true
-					return lastContent
-				}
-				try {
-					const event = JSON.parse(data) as {
-						type?: string
-						content?: string
-						error?: { message?: string }
-					}
-					if (event.type === 'content' && typeof event.content === 'string') {
-						lastContent = event.content
-					} else if (event.type === 'error') {
-						throw new Error(
-							event.error?.message ?? 'Generation failed — please try again',
-						)
-					}
-				} catch (e) {
-					if (e instanceof SyntaxError) continue
-					throw e
-				}
-			}
-		}
-	}
-
-	if (!receivedDone) {
-		throw new Error(
-			'Generation was cut off before completing — the quiz may be too large, please try fewer questions',
-		)
-	}
-
-	return lastContent
-}
-
-const extractJson = (text: string): string => {
-	const start = text.indexOf('{')
-	const end = text.lastIndexOf('}')
-	if (start === -1 || end === -1 || end < start) return text
-	return text.slice(start, end + 1)
-}
 
 function QuizGeneratorPage() {
 	return (
@@ -131,7 +71,7 @@ function QuizGenerateForm() {
 	const [isExtracting, setIsExtracting] = useState(false)
 	const [error, setError] = useState<string | null>(null)
 
-	const createQuiz = useMutation(api.quizContent.create)
+	const generateQuiz = useAction(api.quizGeneration.generate)
 
 	const handleSourceFile = async (file: File) => {
 		setIsExtracting(true)
@@ -166,65 +106,15 @@ function QuizGenerateForm() {
 				.map((t) => t.trim())
 				.filter(Boolean)
 
-			const body: Record<string, unknown> = {
+			const contentId = await generateQuiz({
 				prompt: prompt.trim(),
 				questionCount,
-			}
-			if (sourceText.trim()) body.sourceText = sourceText.trim()
-			if (difficulty) body.difficulty = difficulty
-			if (category.trim()) body.category = slugify(category)
-			if (subcategory.trim()) body.subcategory = slugify(subcategory)
-			if (parsedTags.length > 0) body.tags = parsedTags.map(slugify)
-			if (quizType.trim()) body.quizType = slugify(quizType)
-
-			const res = await fetch('/api/ai/quiz-generate', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
-			})
-
-			if (!res.ok) {
-				const data = await res.json().catch(() => ({}))
-				throw new Error(
-					(data as { error?: string }).error ?? 'Generation failed',
-				)
-			}
-
-			const rawText = await accumulateSseText(res)
-			const cleanedJson = extractJson(rawText.trim())
-			let quiz: {
-				type: string
-				subcategory: string
-				category: string
-				difficulty: 'easy' | 'medium' | 'hard'
-				tags: string[]
-				title: string
-				questions: Array<{
-					question: string
-					options: { label: string; text: string }[]
-					answer: string
-					explanation: string
-					mistakes?: string
-				}>
-			}
-			try {
-				quiz = JSON.parse(cleanedJson)
-			} catch {
-				throw new Error('Failed to parse generated quiz — please try again')
-			}
-			const contentId = `${slugify(quiz.type)}-${slugify(quiz.subcategory)}-${Date.now()}`
-
-			await createQuiz({
-				contentId,
-				type: quiz.type,
-				category: quiz.category,
-				subcategory: quiz.subcategory,
-				difficulty: quiz.difficulty,
-				tags: quiz.tags,
-				version: '1.0.0',
-				title: quiz.title,
-				questions: quiz.questions,
-				sourcePrompt: prompt.trim(),
+				...(sourceText.trim() ? { sourceText: sourceText.trim() } : {}),
+				...(difficulty ? { difficulty } : {}),
+				...(category.trim() ? { category: slugify(category) } : {}),
+				...(subcategory.trim() ? { subcategory: slugify(subcategory) } : {}),
+				...(parsedTags.length > 0 ? { tags: parsedTags.map(slugify) } : {}),
+				...(quizType.trim() ? { quizType: slugify(quizType) } : {}),
 			})
 
 			navigate({

--- a/src/routes/generate/quiz/preview/$contentId.tsx
+++ b/src/routes/generate/quiz/preview/$contentId.tsx
@@ -137,6 +137,7 @@ function DraftPreview({ contentId }: { contentId: string }) {
 	}
 
 	const handlePublish = async () => {
+		if (isEditing) return
 		setIsPublishing(true)
 		setError(null)
 		try {
@@ -149,6 +150,7 @@ function DraftPreview({ contentId }: { contentId: string }) {
 	}
 
 	const handleDelete = async () => {
+		if (isEditing) return
 		setIsDeleting(true)
 		setError(null)
 		try {
@@ -162,6 +164,7 @@ function DraftPreview({ contentId }: { contentId: string }) {
 	}
 
 	const handleRegenerate = () => {
+		if (isEditing) return
 		navigate({
 			to: '/generate/quiz',
 			search: { prompt: draft.sourcePrompt ?? '' },
@@ -222,7 +225,7 @@ function DraftPreview({ contentId }: { contentId: string }) {
 			<div className="flex items-center gap-3 pt-4 border-t border-border">
 				<Button
 					onClick={() => void handlePublish()}
-					disabled={isPublishing || isDeleting}
+					disabled={isPublishing || isDeleting || isEditing}
 				>
 					{isPublishing ? (
 						'Publishing...'
@@ -233,7 +236,7 @@ function DraftPreview({ contentId }: { contentId: string }) {
 						</>
 					)}
 				</Button>
-				<Button variant="outline" onClick={handleRegenerate}>
+				<Button variant="outline" onClick={handleRegenerate} disabled={isEditing}>
 					<RotateCcw size={16} className="mr-1" />
 					Regenerate
 				</Button>
@@ -243,7 +246,7 @@ function DraftPreview({ contentId }: { contentId: string }) {
 							variant="destructive"
 							size="sm"
 							onClick={() => void handleDelete()}
-							disabled={isDeleting}
+							disabled={isDeleting || isEditing}
 						>
 							{isDeleting ? 'Deleting...' : 'Confirm Delete'}
 						</Button>
@@ -261,6 +264,7 @@ function DraftPreview({ contentId }: { contentId: string }) {
 						variant="ghost"
 						size="sm"
 						onClick={() => setConfirmDelete(true)}
+						disabled={isEditing}
 						className="ml-auto text-muted-foreground hover:text-destructive"
 					>
 						<Trash2 size={16} className="mr-1" />
@@ -427,6 +431,7 @@ const MetadataSection = ({
 					<button
 						type="button"
 						onClick={onStartEditing}
+						aria-label="Edit draft metadata"
 						className="p-1 text-muted-foreground hover:text-primary transition-colors"
 					>
 						<Pencil size={14} />

--- a/src/routes/generate/quiz/preview/$contentId.tsx
+++ b/src/routes/generate/quiz/preview/$contentId.tsx
@@ -1,0 +1,534 @@
+import { SignedIn, SignedOut, SignInButton } from '@clerk/clerk-react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useMutation, useQuery } from 'convex/react'
+import {
+	Check,
+	ChevronDown,
+	ChevronUp,
+	Pencil,
+	RotateCcw,
+	Trash2,
+} from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+import { api } from '../../../../../convex/_generated/api'
+
+export const Route = createFileRoute('/generate/quiz/preview/$contentId')({
+	component: QuizPreviewPage,
+})
+
+type Difficulty = 'easy' | 'medium' | 'hard'
+
+function QuizPreviewPage() {
+	const { contentId } = Route.useParams()
+
+	return (
+		<div className="container mx-auto py-8 px-4 max-w-3xl">
+			<SignedOut>
+				<div className="flex flex-col items-center gap-4 py-12">
+					<p className="text-muted-foreground">Sign in to view this draft.</p>
+					<SignInButton mode="modal">
+						<Button>Sign In</Button>
+					</SignInButton>
+				</div>
+			</SignedOut>
+			<SignedIn>
+				<DraftPreview contentId={contentId} />
+			</SignedIn>
+		</div>
+	)
+}
+
+function DraftPreview({ contentId }: { contentId: string }) {
+	const navigate = useNavigate()
+	const draft = useQuery(api.quizContent.getDraft, { contentId })
+	const updateDraft = useMutation(api.quizContent.updateDraft)
+	const publishQuiz = useMutation(api.quizContent.publish)
+	const removeQuiz = useMutation(api.quizContent.remove)
+
+	const [isEditing, setIsEditing] = useState(false)
+	const [isSaving, setIsSaving] = useState(false)
+	const [isPublishing, setIsPublishing] = useState(false)
+	const [isDeleting, setIsDeleting] = useState(false)
+	const [confirmDelete, setConfirmDelete] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+	const [expandedQuestion, setExpandedQuestion] = useState<number | null>(null)
+
+	const [editTitle, setEditTitle] = useState('')
+	const [editType, setEditType] = useState('')
+	const [editCategory, setEditCategory] = useState('')
+	const [editSubcategory, setEditSubcategory] = useState('')
+	const [editDifficulty, setEditDifficulty] = useState<Difficulty>('medium')
+	const [editTags, setEditTags] = useState('')
+
+	if (draft === undefined) {
+		return <p className="text-muted-foreground">Loading draft...</p>
+	}
+
+	if (draft === null) {
+		return (
+			<div className="flex flex-col items-center gap-4 py-12">
+				<p className="text-muted-foreground">
+					This draft is no longer available. It may have been published or
+					deleted.
+				</p>
+				<div className="flex gap-2">
+					<Button
+						variant="outline"
+						onClick={() => navigate({ to: '/quizzes' })}
+					>
+						View Quizzes
+					</Button>
+					<Button
+						variant="outline"
+						onClick={() => navigate({ to: '/generate/quiz/drafts' })}
+					>
+						View Drafts
+					</Button>
+				</div>
+			</div>
+		)
+	}
+
+	const startEditing = () => {
+		setEditTitle(draft.title)
+		setEditType(draft.type)
+		setEditCategory(draft.category)
+		setEditSubcategory(draft.subcategory)
+		setEditDifficulty(draft.difficulty)
+		setEditTags(draft.tags.join(', '))
+		setIsEditing(true)
+	}
+
+	const handleSave = async () => {
+		setIsSaving(true)
+		setError(null)
+		try {
+			const parsedTags = editTags
+				.split(',')
+				.map((t) => t.trim())
+				.filter(Boolean)
+
+			await updateDraft({
+				contentId,
+				title: editTitle,
+				type: editType,
+				category: editCategory,
+				subcategory: editSubcategory,
+				difficulty: editDifficulty,
+				tags: parsedTags,
+			})
+			setIsEditing(false)
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to save')
+		} finally {
+			setIsSaving(false)
+		}
+	}
+
+	const handlePublish = async () => {
+		setIsPublishing(true)
+		setError(null)
+		try {
+			await publishQuiz({ contentId })
+			navigate({ to: '/quizzes' })
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to publish')
+			setIsPublishing(false)
+		}
+	}
+
+	const handleDelete = async () => {
+		setIsDeleting(true)
+		setError(null)
+		try {
+			await removeQuiz({ contentId })
+			navigate({ to: '/generate/quiz/drafts' })
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to delete')
+			setIsDeleting(false)
+			setConfirmDelete(false)
+		}
+	}
+
+	const handleRegenerate = () => {
+		navigate({
+			to: '/generate/quiz',
+			search: { prompt: draft.sourcePrompt ?? '' },
+		})
+	}
+
+	const toggleQuestion = (index: number) => {
+		setExpandedQuestion(expandedQuestion === index ? null : index)
+	}
+
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex items-center justify-between">
+				<h1 className="text-2xl font-bold">Draft Preview</h1>
+				<span className="px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200 text-xs font-medium">
+					Draft
+				</span>
+			</div>
+
+			{error && <p className="text-sm text-destructive">{error}</p>}
+
+			<MetadataSection
+				draft={draft}
+				isEditing={isEditing}
+				isSaving={isSaving}
+				editTitle={editTitle}
+				editType={editType}
+				editCategory={editCategory}
+				editSubcategory={editSubcategory}
+				editDifficulty={editDifficulty}
+				editTags={editTags}
+				onEditTitle={setEditTitle}
+				onEditType={setEditType}
+				onEditCategory={setEditCategory}
+				onEditSubcategory={setEditSubcategory}
+				onEditDifficulty={setEditDifficulty}
+				onEditTags={setEditTags}
+				onStartEditing={startEditing}
+				onSave={() => void handleSave()}
+				onCancel={() => setIsEditing(false)}
+			/>
+
+			<div className="flex flex-col gap-3">
+				<h2 className="text-lg font-semibold">
+					Questions ({draft.questions.length})
+				</h2>
+				{draft.questions.map((q, i) => (
+					<QuestionCard
+						key={`q-${q.answer}-${q.question.slice(0, 20)}`}
+						index={i}
+						question={q}
+						isExpanded={expandedQuestion === i}
+						onToggle={() => toggleQuestion(i)}
+					/>
+				))}
+			</div>
+
+			<div className="flex items-center gap-3 pt-4 border-t border-border">
+				<Button
+					onClick={() => void handlePublish()}
+					disabled={isPublishing || isDeleting}
+				>
+					{isPublishing ? (
+						'Publishing...'
+					) : (
+						<>
+							<Check size={16} className="mr-1" />
+							Publish
+						</>
+					)}
+				</Button>
+				<Button variant="outline" onClick={handleRegenerate}>
+					<RotateCcw size={16} className="mr-1" />
+					Regenerate
+				</Button>
+				{confirmDelete ? (
+					<div className="flex items-center gap-2 ml-auto">
+						<Button
+							variant="destructive"
+							size="sm"
+							onClick={() => void handleDelete()}
+							disabled={isDeleting}
+						>
+							{isDeleting ? 'Deleting...' : 'Confirm Delete'}
+						</Button>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => setConfirmDelete(false)}
+							disabled={isDeleting}
+						>
+							Cancel
+						</Button>
+					</div>
+				) : (
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => setConfirmDelete(true)}
+						className="ml-auto text-muted-foreground hover:text-destructive"
+					>
+						<Trash2 size={16} className="mr-1" />
+						Delete
+					</Button>
+				)}
+			</div>
+		</div>
+	)
+}
+
+type DraftDoc = {
+	title: string
+	type: string
+	category: string
+	subcategory: string
+	difficulty: Difficulty
+	tags: string[]
+}
+
+const MetadataSection = ({
+	draft,
+	isEditing,
+	isSaving,
+	editTitle,
+	editType,
+	editCategory,
+	editSubcategory,
+	editDifficulty,
+	editTags,
+	onEditTitle,
+	onEditType,
+	onEditCategory,
+	onEditSubcategory,
+	onEditDifficulty,
+	onEditTags,
+	onStartEditing,
+	onSave,
+	onCancel,
+}: {
+	draft: DraftDoc
+	isEditing: boolean
+	isSaving: boolean
+	editTitle: string
+	editType: string
+	editCategory: string
+	editSubcategory: string
+	editDifficulty: Difficulty
+	editTags: string
+	onEditTitle: (v: string) => void
+	onEditType: (v: string) => void
+	onEditCategory: (v: string) => void
+	onEditSubcategory: (v: string) => void
+	onEditDifficulty: (v: Difficulty) => void
+	onEditTags: (v: string) => void
+	onStartEditing: () => void
+	onSave: () => void
+	onCancel: () => void
+}) => {
+	if (isEditing) {
+		return (
+			<div className="flex flex-col gap-3 p-4 rounded-lg border border-border bg-card">
+				<div className="flex flex-col gap-2">
+					<Label>Title</Label>
+					<Input
+						value={editTitle}
+						onChange={(e) => onEditTitle(e.target.value)}
+					/>
+				</div>
+				<div className="grid grid-cols-2 gap-3">
+					<div className="flex flex-col gap-2">
+						<Label>Type</Label>
+						<Input
+							value={editType}
+							onChange={(e) => onEditType(e.target.value)}
+						/>
+					</div>
+					<div className="flex flex-col gap-2">
+						<Label>Difficulty</Label>
+						<Select
+							value={editDifficulty}
+							onValueChange={(v) => onEditDifficulty(v as Difficulty)}
+						>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="easy">Easy</SelectItem>
+								<SelectItem value="medium">Medium</SelectItem>
+								<SelectItem value="hard">Hard</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+				</div>
+				<div className="grid grid-cols-2 gap-3">
+					<div className="flex flex-col gap-2">
+						<Label>Category</Label>
+						<Input
+							value={editCategory}
+							onChange={(e) => onEditCategory(e.target.value)}
+						/>
+					</div>
+					<div className="flex flex-col gap-2">
+						<Label>Subcategory</Label>
+						<Input
+							value={editSubcategory}
+							onChange={(e) => onEditSubcategory(e.target.value)}
+						/>
+					</div>
+				</div>
+				<div className="flex flex-col gap-2">
+					<Label>Tags (comma-separated)</Label>
+					<Input
+						value={editTags}
+						onChange={(e) => onEditTags(e.target.value)}
+					/>
+				</div>
+				<div className="flex items-center gap-2">
+					<Button size="sm" onClick={onSave} disabled={isSaving}>
+						{isSaving ? 'Saving...' : 'Save Changes'}
+					</Button>
+					<Button
+						size="sm"
+						variant="ghost"
+						onClick={onCancel}
+						disabled={isSaving}
+					>
+						Cancel
+					</Button>
+				</div>
+			</div>
+		)
+	}
+
+	const difficultyColors: Record<string, string> = {
+		easy: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+		medium:
+			'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+		hard: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+	}
+
+	return (
+		<div className="flex flex-col gap-3 p-4 rounded-lg border border-border bg-card">
+			<div className="flex items-start justify-between">
+				<div className="flex flex-col gap-1">
+					<h2 className="text-lg font-semibold">{draft.title}</h2>
+					<div className="flex items-center gap-2 text-sm text-muted-foreground">
+						<span>{draft.type.replace(/-/g, ' ')}</span>
+						<span>·</span>
+						<span>
+							{draft.category} / {draft.subcategory}
+						</span>
+					</div>
+				</div>
+				<div className="flex items-center gap-2">
+					<span
+						className={cn(
+							'px-2 py-0.5 rounded-full text-xs font-medium capitalize',
+							difficultyColors[draft.difficulty],
+						)}
+					>
+						{draft.difficulty}
+					</span>
+					<button
+						type="button"
+						onClick={onStartEditing}
+						className="p-1 text-muted-foreground hover:text-primary transition-colors"
+					>
+						<Pencil size={14} />
+					</button>
+				</div>
+			</div>
+			{draft.tags.length > 0 && (
+				<div className="flex flex-wrap gap-1">
+					{draft.tags.map((tag) => (
+						<span
+							key={tag}
+							className="px-2 py-0.5 rounded-full bg-secondary text-secondary-foreground text-xs"
+						>
+							{tag}
+						</span>
+					))}
+				</div>
+			)}
+		</div>
+	)
+}
+
+type QuestionData = {
+	question: string
+	options: { label: string; text: string }[]
+	answer: string
+	explanation: string
+	mistakes?: string
+}
+
+const QuestionCard = ({
+	index,
+	question,
+	isExpanded,
+	onToggle,
+}: {
+	index: number
+	question: QuestionData
+	isExpanded: boolean
+	onToggle: () => void
+}) => (
+	<div className="rounded-lg border border-border bg-card overflow-hidden">
+		<button
+			type="button"
+			onClick={onToggle}
+			className="flex items-center justify-between w-full p-4 text-left hover:bg-accent/50 transition-colors"
+		>
+			<span className="font-medium">
+				<span className="text-muted-foreground mr-2">Q{index + 1}.</span>
+				{question.question.length > 100
+					? `${question.question.slice(0, 100)}...`
+					: question.question}
+			</span>
+			{isExpanded ? (
+				<ChevronUp size={16} className="shrink-0 text-muted-foreground" />
+			) : (
+				<ChevronDown size={16} className="shrink-0 text-muted-foreground" />
+			)}
+		</button>
+
+		{isExpanded && (
+			<div className="flex flex-col gap-3 px-4 pb-4 border-t border-border pt-3">
+				<p className="text-sm">{question.question}</p>
+
+				<div className="flex flex-col gap-1">
+					{question.options.map((opt) => (
+						<div
+							key={opt.label}
+							className={cn(
+								'flex items-start gap-2 text-sm px-2 py-1 rounded',
+								opt.label === question.answer &&
+									'bg-green-50 dark:bg-green-950/30 font-medium',
+							)}
+						>
+							<span className="font-mono text-muted-foreground shrink-0">
+								{opt.label}.
+							</span>
+							<span>{opt.text}</span>
+							{opt.label === question.answer && (
+								<Check
+									size={14}
+									className="shrink-0 text-green-600 dark:text-green-400 mt-0.5"
+								/>
+							)}
+						</div>
+					))}
+				</div>
+
+				<div className="flex flex-col gap-1 text-sm">
+					<span className="font-medium text-muted-foreground">Explanation</span>
+					<p>{question.explanation}</p>
+				</div>
+
+				{question.mistakes && (
+					<div className="flex flex-col gap-1 text-sm">
+						<span className="font-medium text-muted-foreground">
+							Common Mistakes
+						</span>
+						<p>{question.mistakes}</p>
+					</div>
+				)}
+			</div>
+		)}
+	</div>
+)

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -1,6 +1,8 @@
 export type Difficulty = 'easy' | 'medium' | 'hard'
 
-export type QuizType = 'pattern-selection' | 'anti-patterns' | 'big-o'
+export type QuizType = string
+
+export type QuizStatus = 'draft' | 'published'
 
 export type ContentSource = 'static' | 'convex'
 
@@ -23,6 +25,7 @@ export type Quiz = {
 	title: string
 	questions: QuizQuestion[]
 	source: ContentSource
+	status?: QuizStatus
 }
 
 export type FlashcardCard = {


### PR DESCRIPTION
## Context

With this PR, we explore an entirely new generator for quizzes; now with the possibility of creating one from a simpler prompt. Plus, importantly, a new lifecycle for quizzes with a draft state enabling the ability to preview quizzes before promoting to the full content list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered quiz generation with streaming output, adjustable question count, optional source text (paste/upload), and guided JSON formatting
  * Drafts workflow: create, list, preview, edit, publish, delete, regenerate; draft-only previews and owner-restricted draft APIs

* **Improvements**
  * Drafts excluded from public listings; quizzes now surface draft/published status
  * Quiz type badge styling and hyphen-to-space label formatting improved
  * Prompt building utilities re-exported for reuse

* **API**
  * Server endpoint for AI quiz generation with realtime streaming responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->